### PR TITLE
RepositoryFetcher: Return complete tempfile instead of path

### DIFF
--- a/app/models/concerns/foreman_git_templates/host_extensions.rb
+++ b/app/models/concerns/foreman_git_templates/host_extensions.rb
@@ -3,9 +3,21 @@
 module ForemanGitTemplates
   module HostExtensions
     def repository_path
-      return unless host_params['template_url']
+      return unless git_template_url
 
-      @repository_path ||= RepositoryFetcher.call(host_params['template_url'])
+      git_template_tmpfile.path
+    end
+
+    private
+
+    def git_template_url
+      @git_template_url ||= host_params['template_url']
+    end
+
+    def git_template_tmpfile
+      return unless git_template_url
+
+      @git_template_tmpfile ||= RepositoryFetcher.call(git_template_url)
     end
   end
 end

--- a/app/services/foreman_git_templates/repository_fetcher.rb
+++ b/app/services/foreman_git_templates/repository_fetcher.rb
@@ -9,7 +9,7 @@ module ForemanGitTemplates
     end
 
     def call
-      Down.download(repository_url).path
+      Down.download(repository_url)
     rescue Down::ResponseError => e
       raise RepositoryFetcherError, "Cannot fetch repository from #{repository_url}. Response code: #{e.response.code}"
     rescue Down::Error => e

--- a/test/models/foreman_git_templates/host_test.rb
+++ b/test/models/foreman_git_templates/host_test.rb
@@ -6,11 +6,12 @@ module ForemanGitTemplates
   class HostTest < ActiveSupport::TestCase
     describe '#repository_path' do
       context 'with template_url parameter' do
-        let(:repo_path) { '/tmp/repo.tar.gz' }
+        let(:repo_tempfile) { Tempfile.new }
+        let(:repo_path) { repo_tempfile.path }
         let(:host) { FactoryBot.create(:host, :managed, :with_template_url) }
 
         it 'returns path to the repository' do
-          ForemanGitTemplates::RepositoryFetcher.expects(:call).once.with(host.params['template_url']).returns(repo_path)
+          ForemanGitTemplates::RepositoryFetcher.expects(:call).once.with(host.params['template_url']).returns(repo_tempfile)
           assert_equal repo_path, host.repository_path
         end
       end


### PR DESCRIPTION
In RepositoryFetcher only the path of the Tempfile created by Down is returned. This could lead to the Tempfile being GC'ed while the path is still used. This fixes #44 